### PR TITLE
Disable quotes for eslint

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -53,7 +53,7 @@ module.exports = {
     ],
     indent: ['error', 2],
     'linebreak-style': ['error', 'unix'],
-    quotes: ['error', 'single'],
+    quotes: 'off',
     semi: ['error', 'always'],
     'eol-last': ['error', 'always'],
     'no-unused-vars': 'off',


### PR DESCRIPTION
prettier handles them and eslint's quote rule conflicts for single quote within a string