### PR TITLE
Specify write perms in deploy action

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - master
+      
+permissions:
+  contents: write
 
 jobs:
   deploy:


### PR DESCRIPTION
Specify write perms in deploy action because gh changed something in actions that needs this property.

Also see [a different gh workflow which works with new gh actions](https://pastebin.com/bCCuXPXU).